### PR TITLE
fix: Migrate Chrome Manifest from v2 to v3

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,11 +1,10 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "ttfm+",
   "description": "A better way to turn tables.",
   "version": "1.0.0",
-
-  "browser_action": {
+  "action": {
     "default_icon": "assets/icon16.png",
     "default_popup": "popup.html"
   },
@@ -25,11 +24,8 @@
     "activeTab",
     "storage"
   ],
-  "optional_permissions": [
-    "<all_urls>"
-  ],
-  "web_accessible_resources": [
-    "styles/darktheme.css",
-    "autolike/index.js"
-  ]
+  "web_accessible_resources": [{
+    "resources": ["styles/darktheme.css", "autolike/index.js"],
+    "matches": ["*://*.turntable.fm/*"]
+  }]
 }

--- a/src/utils/autolike/index.ts
+++ b/src/utils/autolike/index.ts
@@ -1,6 +1,6 @@
 export const setupAutolike = (): void => {
   const script = document.createElement('script');
-  script.src = chrome.extension.getURL('autolike/index.js');
+  script.src = chrome.runtime.getURL('autolike/index.js');
   script.id = 'autolike';
 
   document.querySelector('body').appendChild(script);

--- a/src/utils/darktheme/index.ts
+++ b/src/utils/darktheme/index.ts
@@ -1,6 +1,6 @@
 export const addDarkThemeCSS = (): void => {
   const link = document.createElement('link');
-  link.href = chrome.extension.getURL('styles/darktheme.css');
+  link.href = chrome.runtime.getURL('styles/darktheme.css');
   link.type = 'text/css';
   link.rel = 'stylesheet';
   link.id = 'darkThemeCSS';


### PR DESCRIPTION
### What?

Closes #16. This updates the manifest version to v3 since v2 is being deprecated in January 2023.

### How to test it?

1. Run `npm run build` on this branch
2. Load the unpacked `dist` into `chrome://extensions` (make sure Developer mode is enabled)
3. Make sure nothing breaks
